### PR TITLE
Improve Docker deployment with proxy support for network-restricted e…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@
 # Stage 1: Builder
 FROM python:3.9-slim as builder
 
+# Configure proxy for apt (if needed)
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ENV HTTP_PROXY=${HTTP_PROXY}
+ENV HTTPS_PROXY=${HTTPS_PROXY}
+
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
     gcc \


### PR DESCRIPTION
…nvironments

- Add HTTP_PROXY and HTTPS_PROXY build arguments to Dockerfile for apt package installation
- Enhance deploy.sh script with automatic proxy address conversion for Docker containers
- Convert localhost proxy addresses to Docker-accessible host IP automatically
- Fix permission handling in deploy.sh to work on NAS environments without sudo
- Support proxy environments commonly used in corporate or restricted networks

🤖 Generated with [Claude Code](https://claude.ai/code)